### PR TITLE
adds plugins to Apollo Server to append custom headers and x-forwarded header to gql response

### DIFF
--- a/helpers/callbackend.js
+++ b/helpers/callbackend.js
@@ -17,6 +17,13 @@ module.exports = async ({ context: { req }, requestOptions }) => {
   // Reading the headers Out of the context since it is not passed automatically
   const { headers: { authorization } } = req
   const headers = { authorization }
+  if(req.headers) {
+    Object.entries(req.headers).forEach(([key, value]) => {
+      if (key.indexOf('x-forwarded') !== -1 || key.indexOf('x-original') !== -1) {
+        headers[key] = value
+      }
+    })
+  }
   const bodyAndHeaders = getBodyAndHeaders(body, bodyType, headers)
 
   const response = await fetch(url, {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const { ApolloServer } = require('apollo-server')
 const { mergeSchemas } = require('graphql-tools')
 const schemaLoader = require('./helpers/schema-loader')
+const httpheaderPlugin = require('./plugins/http-headers-plugin')
 
 /**
  * @param {GraqhQLSchema} localSchema
@@ -17,7 +18,9 @@ module.exports = async ({
   endpointsList,
   apolloServerConfig,
   contextConfig,
-  logger
+  logger,
+  customHeaders = [],
+  plugins = []
 }) => {
   logger = logger || console
 
@@ -38,6 +41,7 @@ module.exports = async ({
   return new ApolloServer({
     ...apolloServerConfig,
     schema: mergedSchemas,
+    plugins: [httpheaderPlugin, ...plugins],
     context: (integrationContext) => ({
       ...integrationContext,
       ...contextConfig,
@@ -45,7 +49,8 @@ module.exports = async ({
       resolveSchema: (schameName) => {
         const remoteSchema = services.find(service => service.name === schameName)
         return remoteSchema.schema
-      }
+      },
+      setHeaders: new Array(...customHeaders)
     })
   })
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,34 @@
 {
+  "name": "gql-gateway",
+  "description": "GraphQL Gateway that does magic on top of REST services that provides Swagger/OpenAPI specifications.",
+  "keywords": [
+    "graphql",
+    "gateway",
+    "swagger"
+  ],
+  "version": "1.0.8",
+  "license": "MIT",
   "author": {
     "name": "Ivan Martinez Pupo",
     "email": "segpacto@yahoo.es"
   },
+  "homepage": "https://github.com/segpacto/gql-gateway#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/segpacto/gql-gateway.git"
+  },
   "bugs": {
     "url": "https://github.com/segpacto/gql-gateway/issues"
+  },
+  "files": [
+    "index.js",
+    "helpers"
+  ],
+  "main": "index.js",
+  "scripts": {
+    "lint:fix": "npx standard --fix",
+    "lint": "npx standard",
+    "test": "jest --coverage --detectOpenHandles --runInBand --testRegex=test/.*\\.spec\\.js --testPathIgnorePatterns=test/mocks/*.js"
   },
   "dependencies": {
     "apollo-server": "^2.9.16",
@@ -14,7 +38,6 @@
     "swagger-to-graphql": "^4.0.2",
     "node-fetch": "^2.6.0"
   },
-  "description": "GraphQL Gateway that does magic on top of REST services that provides Swagger/OpenAPI specifications.",
   "devDependencies": {
     "apollo-server-testing": "^2.9.16",
     "dotenv": "^8.2.0",
@@ -23,32 +46,9 @@
     "nodemon": "^2.0.2",
     "standard": "^14.3.1"
   },
-  "homepage": "https://github.com/segpacto/gql-gateway#readme",
-  "keywords": [
-    "graphql",
-    "gateway",
-    "swagger"
-  ],
-  "license": "MIT",
-  "main": "index.js",
-  "name": "gql-gateway",
-  "repository": {
-    "type": "git",
-    "url": "git+ssh://git@github.com/segpacto/gql-gateway.git"
-  },
-  "files": [
-    "index.js",
-    "helpers"
-  ],
-  "scripts": {
-    "lint:fix": "npx standard --fix",
-    "lint": "npx standard",
-    "test": "jest --coverage --detectOpenHandles --runInBand --testRegex=test/.*\\.spec\\.js --testPathIgnorePatterns=test/mocks/*.js"
-  },
   "standard": {
     "env": [
       "jest"
     ]
-  },
-  "version": "1.0.8"
+  }
 }

--- a/plugins/http-headers-plugin.js
+++ b/plugins/http-headers-plugin.js
@@ -1,0 +1,26 @@
+module.exports =
+{
+  requestDidStart: () => {
+    return {
+      willSendResponse (requestContext) {
+        const { setHeaders = [] } = requestContext.context
+
+        if (!Array.isArray(requestContext.context.setHeaders)) {
+          console.warn('headers must be an array of objects in format [{key: headerTitle, value: headerValue}]')
+        }
+        setHeaders.forEach(({ key, value }) => {
+          requestContext.response.http.headers.append(key, value)
+        })
+
+        if(requestContext.request.http) {
+          requestContext.request.http.headers.forEach((value, key) => {
+            if (key.indexOf('x-forwarded') !== -1 || key.indexOf('x-original') !== -1) {
+              requestContext.response.http.headers.append(key, value)
+            }
+          })
+        }
+        return requestContext
+      }
+    }
+  }
+}

--- a/test/construct.spec.js
+++ b/test/construct.spec.js
@@ -16,7 +16,7 @@ describe('Server construct', () => {
       await gateway({ endpointsList })
     } catch (err) {
       expect(err.code).toBe('ENOTFOUND')
-      expect(err.message).toBe('request to https://no-existent-endpoint/swagger.json failed, reason: getaddrinfo ENOTFOUND no-existent-endpoint no-existent-endpoint:443')
+      expect(err.message).toBe('request to https://no-existent-endpoint/swagger.json failed, reason: getaddrinfo ENOTFOUND no-existent-endpoint')
     }
   })
 


### PR DESCRIPTION
### Summary

**1.**
I've introduced a hook onto the Apollo Provider instantiation in './index.js'
This hook allows for the injecting of Apollo Server Plugins.
https://www.apollographql.com/docs/apollo-server/integrations/plugins/

**2.  Apollo Server Response to Apollo-Client Request** 
I've also written a plugin 
This plugin attaches x-forward headers 
**from**  incoming gql Request (from website)
**to**      returning Response (back to website)


**3.  Apollo-Server Request to backend API**
In the file 'helpers/callbackend.js'
I've reattached x-forward header
**from**  incoming gql Request (from website) 
**to**      outgoing Requests (to backend api)