### PR TITLE
Enabling connection context on subscription resolvers

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ module.exports = async ({
       ...integrationContext,
       ...contextConfig,
       req: integrationContext.req,
+      connection: integrationContext.connection,
       resolveSchema: (schameName) => {
         const remoteSchema = services.find(service => service.name === schameName)
         return remoteSchema.schema

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "gateway",
     "swagger"
   ],
-  "version": "1.0.9",
+  "version": "1.0.10",
   "license": "MIT",
   "author": {
     "name": "Ivan Martinez Pupo",


### PR DESCRIPTION
Adding subscription  'connection' into the context as it is done with 'req' for queries and mutations.